### PR TITLE
missing parenthesis.

### DIFF
--- a/who.lisp
+++ b/who.lisp
@@ -287,7 +287,7 @@ supplied."
                   (with-unique-names (result)
                     `(let ((,result ,thing))
                        (when ,result (princ ,result ,',var))))))
-       ,@(apply 'tree-to-commands body var rest))))
+         (,@(apply 'tree-to-commands body var rest)))))
 
 (defmacro with-html-output-to-string ((var &optional string-form
                                            &key (element-type #-:lispworks ''character


### PR DESCRIPTION
in with-html-output, the generated code has an implicit progn that is not surronded with parenthesis.
