### PR TITLE
Fix for SGML mode

### DIFF
--- a/who.lisp
+++ b/who.lisp
@@ -117,7 +117,7 @@ forms."
                                 ((eq ,=var= t)
                                  ,(case *html-mode*
                                     (:sgml
-                                     `(fmt " ~A" attr))
+                                     `(fmt " ~A" ,attr))
                                     ;; otherwise default to :xml mode
                                     (t
                                      `(fmt " ~A=~C~A~C"


### PR DESCRIPTION
Here's a fix for boolean attribute value related typo demonstrated by the following code:

``` commonlisp
(setf (cl-who:html-mode) :sgml)

(let ((v t))
  (cl-who:with-html-output (*standard-output*)
    (:input :type "text" :disabled v)))
```
