### PR TITLE
Adding missing comma

### DIFF
--- a/who.lisp
+++ b/who.lisp
@@ -117,7 +117,7 @@ forms."
                                 ((eq ,=var= t)
                                  ,(case *html-mode*
                                     (:sgml
-                                     `(fmt " ~A" attr))
+                                     `(fmt " ~A" ,attr))
                                     ;; otherwise default to :xml mode
                                     (t
                                      `(fmt " ~A=~C~A~C"


### PR DESCRIPTION
There has been a comma missing for sometime in who.lisp in the line:
`(fmt " ~A" attr))
which causes warnings when building this package. Can't be healthy. With the comma in place the warnings go away and it passes every test I can think of to run on it. 
