### PR TITLE
Add a type-check for a stream in with-html-output.

### DIFF
--- a/who.lisp
+++ b/who.lisp
@@ -280,6 +280,7 @@ supplied."
   (multiple-value-bind (declarations forms) (extract-declarations body)
   `(let ((,var ,(or stream var)))
        ,@declarations
+     (check-type ,var stream)
      (macrolet ((htm (&body body)
                   `(with-html-output (,',var nil :prologue nil :indent ,,indent)
                      ,@body))


### PR DESCRIPTION
Avoids confusion caused in Issue #14.
