### PR TITLE
Adapt defconstant for clasp (behaving like sbcl)

### DIFF
--- a/packages.lisp
+++ b/packages.lisp
@@ -32,7 +32,7 @@
 (defpackage :cl-who
   (:use :cl)
   (:nicknames :who)
-  #+:sbcl (:shadow :defconstant)
+  #+(or :clasp :sbcl) (:shadow :defconstant)
   #+:sb-package-locks (:lock t)
   (:export :*attribute-quote-char*
            :*empty-attribute-syntax*

--- a/specials.lisp
+++ b/specials.lisp
@@ -29,9 +29,9 @@
 
 (in-package :cl-who)
 
-#+:sbcl
+#+(or :clasp :sbcl)
 (defmacro defconstant (name value &optional doc)
-  "Make sure VALUE is evaluated only once \(to appease SBCL)."
+  "Make sure VALUE is evaluated only once \(to appease SBCL & clasp)."
   `(cl:defconstant ,name (if (boundp ',name) (symbol-value ',name) ,value)
      ,@(when doc (list doc))))
 


### PR DESCRIPTION
w/o this clasp will complain on defconstants being redefined if they are not eql (as sbcl)