### PR TITLE
fix asdf warning and broken tests

### DIFF
--- a/cl-who.asd
+++ b/cl-who.asd
@@ -35,15 +35,12 @@
   :components ((:file "packages")
                (:file "specials")
                (:file "util")
-               (:file "who")))
+               (:file "who"))
+  :perform (test-op (o c) (symbol-call :cl-who-test '#:run-all-tests)))
 
-(defsystem :cl-who-test
+(defsystem :cl-who/test
   :depends-on (:cl-who :flexi-streams)
   :components ((:module "test"
                         :serial t
                         :components ((:file "packages")
                                      (:file "tests")))))
-
-(defmethod perform ((o test-op) (c (eql (find-system :cl-who))))
-  (operate 'load-op :cl-who-test)
-  (funcall (intern (symbol-name :run-all-tests) (find-package :cl-who-test))))

--- a/test/simple
+++ b/test/simple
@@ -246,7 +246,7 @@
 ;;; 21
 (string= (with-html-output-to-string (out)
            (:|Foo| :bar 42))
-         "<foo bar='42'></foo>")
+         "<Foo bar='42'></Foo>")
 
 ;;; 22
 (string= (let ((*downcase-tokens-p* nil))


### PR DESCRIPTION
- resolves https://github.com/edicl/cl-who/issues/36
- added :perform instead of the method definition seemed unnecessary
- corrected downcase test - see body of cl-who::maybe-downcase - only applies when entire symbol name sats cl-who::same-case-p
- removed sbcl exclusion from with-html-output-to-string :ELEMENT-TYPE keyword (why is this here? can we remove other exclusions?) - alternatively apply these exclusions to the test form so that it gets skipped.